### PR TITLE
add attribute name to code list table headers + remove duplicate code rows in tables

### DIFF
--- a/udd/course.md
+++ b/udd/course.md
@@ -77,9 +77,1088 @@ For display purposes and further analysis
 https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&href=a^_^COURSEAIM.html
 
 ###Valid Values
-https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&href=a^_^COURSEAIM.html
-  
-- plus additional codes X98 & X99 (see notes below)  
+<table>
+ <tr>
+  <td>COURSE_AIM</td>
+  <td>DESCRIPTION (ENGLISH)</td>
+  <td>DESCRIPTION (WELSH)</td>
+  <td>HESA</td>
+  <td>FEILR</td>
+ </tr>
+ <tr>
+  <td>D00</td>
+  <td>Doctorate degree that meets the criteria for a research-based higher degree</td>
+  <td></td>
+  <td>D00</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>D01</td>
+  <td>New Route PhD that meets the criteria for a research-based higher degree</td>
+  <td></td>
+  <td>D01</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>D90</td>
+  <td>Provider credit at level D that can count towards a research-based higher degree</td>
+  <td></td>
+  <td>D90</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>E00</td>
+  <td>Doctorate degree that does not meet the criteria for a research-based higher degree</td>
+  <td></td>
+  <td>E00</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>E40</td>
+  <td>National Vocational Qualification (NVQ) at level E</td>
+  <td></td>
+  <td>E40</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>E43</td>
+  <td>Highly specialist diploma from a professional body</td>
+  <td></td>
+  <td>E43</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>E90</td>
+  <td>Advanced taught study at level E for provider credit</td>
+  <td></td>
+  <td>E90</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>L00</td>
+  <td>Masters degree that meets the criteria for a research-based higher degree</td>
+  <td></td>
+  <td>L00</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>L80</td>
+  <td>Other postgraduate qualification at level L that meets the criteria for a research-based higher degree</td>
+  <td></td>
+  <td>L80</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>L90</td>
+  <td>Provider credit at level L that can count towards a research-based higher degree</td>
+  <td></td>
+  <td>L90</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>L91</td>
+  <td>Visiting research students at levels D or L, with formal or informal credit</td>
+  <td></td>
+  <td>L91</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>L99</td>
+  <td>Research-based higher degree where the student may ultimately study at levels D or L</td>
+  <td></td>
+  <td>L99</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M00</td>
+  <td>Masters degree obtained typically by a combination of coursework and thesis/dissertation, that does not meet the criteria for a research-based higher degree</td>
+  <td></td>
+  <td>M00</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M01</td>
+  <td>Taught masters degree designed specifically as a training in research methods and intended as a preparation for a research-based higher degree</td>
+  <td></td>
+  <td>M01</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M02</td>
+  <td>Masters in Teaching and Learning</td>
+  <td></td>
+  <td>M02</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M10</td>
+  <td>Post-experience taught masters degree</td>
+  <td></td>
+  <td>M10</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M11</td>
+  <td>Master of Business Administration (MBA)</td>
+  <td></td>
+  <td>M11</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M16</td>
+  <td>Pre-registration masters degree leading towards obtaining eligibility to register to practice with a health or social care or veterinary statutory regulatory body</td>
+  <td></td>
+  <td>M16</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M22</td>
+  <td>Integrated undergraduate/postgraduate taught masters degree on the enhanced/extended pattern</td>
+  <td></td>
+  <td>M22</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M26</td>
+  <td>Integrated undergraduate/postgraduate taught masters degree on the enhanced/extended pattern leading towards obtaining eligibility to register to practice with a health or social care or veterinary statutory regulatory body</td>
+  <td></td>
+  <td>M26</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M28</td>
+  <td>Integrated undergraduate/postgraduate taught masters degree on the enhanced/extended pattern leading towards registration with the Architects Registration Board (Part 1 and Part 2 qualification)</td>
+  <td></td>
+  <td>M28</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M40</td>
+  <td>Fellowship at level M</td>
+  <td></td>
+  <td>M40</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M41</td>
+  <td>Diploma at level M</td>
+  <td></td>
+  <td>M41</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M42</td>
+  <td>Advanced professional certificate at level M</td>
+  <td></td>
+  <td>M42</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M43</td>
+  <td>National Vocational Qualification (NVQ) at level M</td>
+  <td></td>
+  <td>M43</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M44</td>
+  <td>Certificate at level M</td>
+  <td></td>
+  <td>M44</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M45</td>
+  <td>Scottish Vocational Qualification (SVQ) 5</td>
+  <td></td>
+  <td>M45</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M50</td>
+  <td>Postgraduate bachelors degree at level M obtained typically by a combination of coursework and thesis/dissertation, that does not meet the criteria for a research-based higher degree</td>
+  <td></td>
+  <td>M50</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M70</td>
+  <td>Professional taught qualification at level M other than a masters degree</td>
+  <td></td>
+  <td>M70</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M71</td>
+  <td>Postgraduate Certificate in Education or Professional Graduate Diploma in Education</td>
+  <td></td>
+  <td>M71</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M72</td>
+  <td>Post-registration education qualification at level M other than a masters degree for serving schoolteachers</td>
+  <td></td>
+  <td>M72</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M76</td>
+  <td>Post-registration health and social care qualification at level M</td>
+  <td></td>
+  <td>M76</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M78</td>
+  <td>Taught qualification at level M (where qualification at level H and/or level M is a pre-requisite for course entry) leading towards registration with the Architects Registration Board (Part 3 qualification)</td>
+  <td></td>
+  <td>M78</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M79</td>
+  <td>Level 7 Diploma in Teaching in the Lifelong Learning Sector</td>
+  <td></td>
+  <td>M79</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M80</td>
+  <td>Other taught qualification at level M</td>
+  <td></td>
+  <td>M80</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M86</td>
+  <td>Taught qualification at level M leading towards obtaining eligibility to register to practice with a health or social care or veterinary statutory regulatory body</td>
+  <td></td>
+  <td>M86</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M88</td>
+  <td>Taught qualification at level M (where a qualification at level H is a pre-requisite for course entry) leading towards registration with the Architects Registration Board (Part 2 qualification)</td>
+  <td></td>
+  <td>M88</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M90</td>
+  <td>Taught work at level M for provider credit</td>
+  <td></td>
+  <td>M90</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M91</td>
+  <td>Visiting taught students at levels E or M, with formal or informal credit</td>
+  <td></td>
+  <td>M91</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>M99</td>
+  <td>Taught work at levels E or M with an unspecified qualification aim</td>
+  <td></td>
+  <td>M99</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H00</td>
+  <td>First degree with honours</td>
+  <td></td>
+  <td>H00</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H11</td>
+  <td>First degree with honours leading to Qualified Teacher Status (QTS)/registration with a General Teaching Council (GTC)</td>
+  <td></td>
+  <td>H11</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H12</td>
+  <td>First degree with honours leading to Early Years Teacher Status (EYTS)</td>
+  <td></td>
+  <td>H12</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H16</td>
+  <td>Pre-registration first degree with honours leading towards obtaining eligibility to register to practice with a health or social care or veterinary statutory regulatory body</td>
+  <td></td>
+  <td>H16</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H18</td>
+  <td>First degree with honours leading towards registration with the Architects Registration Board (Part 1 qualification)</td>
+  <td></td>
+  <td>H18</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H22</td>
+  <td>First degree with honours on the enhanced/extended pattern but at level H</td>
+  <td></td>
+  <td>H22</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H23</td>
+  <td>First degree with honours and diploma</td>
+  <td></td>
+  <td>H23</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H41</td>
+  <td>Diploma at level H</td>
+  <td></td>
+  <td>H41</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H42</td>
+  <td>Certificate at level H</td>
+  <td></td>
+  <td>H42</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H43</td>
+  <td>National Vocational Qualification (NVQ) at level H</td>
+  <td></td>
+  <td>H43</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H50</td>
+  <td>Postgraduate bachelors degree at level H</td>
+  <td></td>
+  <td>H50</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H60</td>
+  <td>Graduate diploma/certificate at level H</td>
+  <td></td>
+  <td>H60</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H61</td>
+  <td>Graduate diploma/certificate at level H but where a previous qualification at level H is a pre-requisite for course entry</td>
+  <td></td>
+  <td>H61</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H62</td>
+  <td>Pre-registration graduate diploma/certificate leading towards obtaining eligibility to register to practice with a health or social care or veterinary statutory regulatory
+body</td>
+  <td></td>
+  <td>H62</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H70</td>
+  <td>Professional qualification at level H other than a first degree with honours</td>
+  <td></td>
+  <td>H70</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H71</td>
+  <td>Professional Graduate Certificate in Education</td>
+  <td></td>
+  <td>H71</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H72</td>
+  <td>Professional qualification at level H for serving schoolteachers other than a first degree with honours</td>
+  <td></td>
+  <td>H72</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H76</td>
+  <td>Post-registration health and social care qualification at level H other than a first degree with honours</td>
+  <td></td>
+  <td>H76</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H78</td>
+  <td>Other qualification at level H (where other qualifications at level H are a pre-requisite for course entry) leading towards registration with the Architects Registration Board (Part 3 qualification)</td>
+  <td></td>
+  <td>H78</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H79</td>
+  <td>Level 6 Diploma in Teaching in the Lifelong Learning Sector</td>
+  <td></td>
+  <td>H79</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H80</td>
+  <td>Other qualification at level H</td>
+  <td></td>
+  <td>H80</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H81</td>
+  <td>Other qualification at level H but where a previous qualification at level H is a pre-requisite for course entry</td>
+  <td></td>
+  <td>H81</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H88</td>
+  <td>Qualification at level H (where another qualification at level H is a pre-requisite for course entry) leading towards registration with the Architects Registration Board (Part 2 qualification)</td>
+  <td></td>
+  <td>H88</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H90</td>
+  <td>Credits at level H</td>
+  <td></td>
+  <td>H90</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H91</td>
+  <td>Visiting students at level H, with formal or informal credit</td>
+  <td></td>
+  <td>H91</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>H99</td>
+  <td>Taught work at level H with an unspecified qualification aim</td>
+  <td></td>
+  <td>H99</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I00</td>
+  <td>Ordinary (non-honours) first degree</td>
+  <td></td>
+  <td>I00</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I11</td>
+  <td>Ordinary (non-honours) first degree leading to Qualified Teacher Status (QTS)/registration with a General Teaching Council (GTC)</td>
+  <td></td>
+  <td>I11</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I12</td>
+  <td>Ordinary (non-honours) first degree leading to Early Years Teacher Status (EYTS)</td>
+  <td></td>
+  <td>I12</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I16</td>
+  <td>Pre-registration ordinary (non-honours) first degree leading towards obtaining eligibility to register to practice with a health or social care or veterinary statutory regulatory body</td>
+  <td></td>
+  <td>I16</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I60</td>
+  <td>Graduate diploma/certificate at level I</td>
+  <td></td>
+  <td>I60</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I61</td>
+  <td>Graduate diploma/certificate at level I but where a previous qualification at level I or H is a pre-requisite for course entry</td>
+  <td></td>
+  <td>I61</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I70</td>
+  <td>Professional qualification at level I other than an ordinary (non-honours) first degree</td>
+  <td></td>
+  <td>I70</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I71</td>
+  <td>Qualified Teacher Status (QTS)/registration with a General Teaching Council (GTC) only</td>
+  <td></td>
+  <td>I71</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I72</td>
+  <td>Professional qualification at level I for serving schoolteachers</td>
+  <td></td>
+  <td>I72</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I73</td>
+  <td>Early Years Teacher Status (EYTS) only</td>
+  <td></td>
+  <td>I73</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I74</td>
+  <td>Teaching certificate (trained through the medium of Welsh)</td>
+  <td></td>
+  <td>I74</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I76</td>
+  <td>Post-registration health and social care qualification at level I other than an ordinary (non-honours) first degree</td>
+  <td></td>
+  <td>I76</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I79</td>
+  <td>Level 5 Diploma in Teaching in the Lifelong Learning Sector</td>
+  <td></td>
+  <td>I79</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I80</td>
+  <td>Other qualification at level I</td>
+  <td></td>
+  <td>I80</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I81</td>
+  <td>Other qualification at level I but where a previous qualification at level I or H is a pre-requisite for course entry</td>
+  <td></td>
+  <td>I81</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I90</td>
+  <td>Credits at level I</td>
+  <td></td>
+  <td>I90</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I91</td>
+  <td>Visiting students at level I, with formal or informal credit</td>
+  <td></td>
+  <td>I91</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>I99</td>
+  <td>Taught work at level I with an unspecified qualification  aim</td>
+  <td></td>
+  <td>I99</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>J10</td>
+  <td>Foundation degree</td>
+  <td></td>
+  <td>J10</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>J16</td>
+  <td>Foundation degree which on completion meets entry  requirement for pre-registration health and social care qualification</td>
+  <td></td>
+  <td>J16</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>J20</td>
+  <td>Diploma of Higher Education (DipHE)</td>
+  <td></td>
+  <td>J20</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>J26</td>
+  <td>Diploma of Higher Education (DipHE) leading towards obtaining eligibility to register to practice with a health or social care or veterinary statutory regulatory body</td>
+  <td></td>
+  <td>J26</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>J30</td>
+  <td>Higher National Diploma (HND)</td>
+  <td></td>
+  <td>J30</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>J41</td>
+  <td>Diploma at level J</td>
+  <td></td>
+  <td>J41</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>J42</td>
+  <td>Certificate at level J</td>
+  <td></td>
+  <td>J42</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>J43</td>
+  <td>National Vocational Qualification (NVQ) at level J</td>
+  <td></td>
+  <td>J43</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>J45</td>
+  <td>Scottish Vocational Qualification (SVQ) 4</td>
+  <td></td>
+  <td>J45</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>J76</td>
+  <td>Post-registration health and social care qualification at level J</td>
+  <td></td>
+  <td>J76</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>J80</td>
+  <td>Other qualification at level J</td>
+  <td></td>
+  <td>J80</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>J90</td>
+  <td>Credits at level J</td>
+  <td></td>
+  <td>J90</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>J99</td>
+  <td>Taught work at level J with an unspecified qualification aim</td>
+  <td></td>
+  <td>J99</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>C20</td>
+  <td>Certificate of Higher Education (CertHE)</td>
+  <td></td>
+  <td>C20</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>C30</td>
+  <td>Higher National Certificate (HNC)</td>
+  <td></td>
+  <td>C30</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>C41</td>
+  <td>Diploma at level C</td>
+  <td></td>
+  <td>C41</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>C42</td>
+  <td>Certificate at level C</td>
+  <td></td>
+  <td>C42</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>C43</td>
+  <td>National Vocational Qualification (NVQ) at level C</td>
+  <td></td>
+  <td>C43</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>C77</td>
+  <td>Level 4 Preparing to Teach in the Lifelong Learning Sector</td>
+  <td></td>
+  <td>C77</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>C78</td>
+  <td>Level 4 Certificate in Teaching in the Lifelong Learning Sector</td>
+  <td></td>
+  <td>C78</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>C80</td>
+  <td>Other qualification at level C</td>
+  <td></td>
+  <td>C80</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>C90</td>
+  <td>Credits at level C</td>
+  <td></td>
+  <td>C90</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>C99</td>
+  <td>Taught work at level C with an unspecified qualification aim</td>
+  <td></td>
+  <td>C99</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>P41</td>
+  <td>Diploma at level P</td>
+  <td></td>
+  <td>P41</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>P42</td>
+  <td>Certificate at level P</td>
+  <td></td>
+  <td>P42</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>P43</td>
+  <td>National Vocational Qualification (NVQ) 3</td>
+  <td></td>
+  <td>P43</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>P45</td>
+  <td>Scottish Vocational Qualification (SVQ) 3</td>
+  <td></td>
+  <td>P45</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>P50</td>
+  <td>A/AS level</td>
+  <td></td>
+  <td>P50</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>P55</td>
+  <td>Advanced Higher (Scotland)</td>
+  <td></td>
+  <td>P55</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>P56</td>
+  <td>Higher (Scotland)</td>
+  <td></td>
+  <td>P56</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>P70</td>
+  <td>Professional qualification at level 3</td>
+  <td></td>
+  <td>P70</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>P77</td>
+  <td>Level 3 Preparing to Teach in the Lifelong Learning Sector</td>
+  <td></td>
+  <td>P77</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>P78</td>
+  <td>Level 3 Certificate in Teaching in the Lifelong Learning Sector</td>
+  <td></td>
+  <td>P78</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>P80</td>
+  <td>Other qualification at level 3</td>
+  <td></td>
+  <td>P80</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>P85</td>
+  <td>Diploma in Foundation Studies (Art and Design) at level 3</td>
+  <td></td>
+  <td>P85</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>P90</td>
+  <td>Credits at level 3</td>
+  <td></td>
+  <td>P90</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>Q41</td>
+  <td>Diploma at level Q</td>
+  <td></td>
+  <td>Q41</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>Q42</td>
+  <td>Certificate at level Q</td>
+  <td></td>
+  <td>Q42</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>Q43</td>
+  <td>National Vocational Qualification (NVQ) 2</td>
+  <td></td>
+  <td>Q43</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>Q45</td>
+  <td>Scottish Vocational Qualification (SVQ) 2</td>
+  <td></td>
+  <td>Q45</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>Q50</td>
+  <td>GCSE at grade A*-C</td>
+  <td></td>
+  <td>Q50</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>Q56</td>
+  <td>Intermediate 2 (Scotland)</td>
+  <td></td>
+  <td>Q56</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>Q57</td>
+  <td>Standard Grade Credit (Scotland)</td>
+  <td></td>
+  <td>Q57</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>Q70</td>
+  <td>Professional qualification at level 2</td>
+  <td></td>
+  <td>Q70</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>Q80</td>
+  <td>Other qualification at level 2</td>
+  <td></td>
+  <td>Q80</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>Q90</td>
+  <td>Credits at level 2</td>
+  <td></td>
+  <td>Q90</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>R42</td>
+  <td>Certificate at level R</td>
+  <td></td>
+  <td>R42</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>R43</td>
+  <td>National Vocational Qualification (NVQ) 1</td>
+  <td></td>
+  <td>R43</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>R45</td>
+  <td>Scottish Vocational Qualification (SVQ) 1</td>
+  <td></td>
+  <td>R45</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>R50</td>
+  <td>GCSE at grade D-G</td>
+  <td></td>
+  <td>R50</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>R56</td>
+  <td>Intermediate 1 (Scotland)</td>
+  <td></td>
+  <td>R56</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>R57</td>
+  <td>Standard Grade General (Scotland)</td>
+  <td></td>
+  <td>R57</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>R70</td>
+  <td>Professional qualification at level 1</td>
+  <td></td>
+  <td>R70</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>R80</td>
+  <td>Other qualification at level 1</td>
+  <td></td>
+  <td>R80</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>R90</td>
+  <td>Credits at level 1</td>
+  <td></td>
+  <td>R90</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>S42</td>
+  <td>National Vocational Qualification (NVQ) Entry level certificate</td>
+  <td></td>
+  <td>S42</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>S57</td>
+  <td>Standard Grade Foundation (Scotland)</td>
+  <td></td>
+  <td>S57</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>S80</td>
+  <td>Other qualification at further education (FE) access level</td>
+  <td></td>
+  <td>S80</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>S90</td>
+  <td>Credits at further education (FE) access level</td>
+  <td></td>
+  <td>S90</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>X00</td>
+  <td>Higher education (HE) access course, Quality Assurance Agency (QAA) recognised</td>
+  <td></td>
+  <td>X00</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>X01</td>
+  <td>Higher education (HE) access course, not Quality Assurance Agency (QAA) recognised</td>
+  <td></td>
+  <td>X01</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>X41</td>
+  <td>Welsh for Adults Entry level</td>
+  <td></td>
+  <td>X41</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>X42</td>
+  <td>Welsh for Adults level 1</td>
+  <td></td>
+  <td>X42</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>X43</td>
+  <td>Welsh for Adults level 2</td>
+  <td></td>
+  <td>X43</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>X44</td>
+  <td>Welsh for Adults level 3</td>
+  <td></td>
+  <td>X44</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>X45</td>
+  <td>Welsh for Adults level 4</td>
+  <td></td>
+  <td>X45</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>X46</td>
+  <td>Welsh for Adults specialist/arbennig</td>
+  <td></td>
+  <td>X46</td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>X98</td>
+  <td>No formal qualification aim, below FE level</td>
+  <td></td>
+  <td></td>
+  <td></td>
+ </tr>
+ <tr>
+  <td>X99</td>
+  <td>No formal qualification aim, below HE level</td>
+  <td></td>
+  <td>X99</td>
+  <td></td>
+ </tr>
+</table>
+ 
 
 ###References
 

--- a/udd/module.md
+++ b/udd/module.md
@@ -86,7 +86,7 @@ Int
 Level of credit points - indicates the level of module the student is studying. This has been initially based on the HESA field LEVELPTS, however may be utilised and adapted to also cater for FE
 
 ###Purpose
-Analytics 
+Analytics
 
 ###Derivation
 Jisc
@@ -94,7 +94,7 @@ Jisc
 ###Valid Values
 
 <table>
-<tr><td>CODE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
+<tr><td>MOD_LEVEL</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
 <tr><td>0</td><td>Entry level</td><td>  </td></tr>
 <tr><td>1</td><td>HE Certificate/NVQ Level 4 or equivalent</td><td> 	</td></tr>
 <tr><td>2</td><td>HE Intermediate</td><td> 	</td></tr>
@@ -109,7 +109,7 @@ Jisc
 <tr><td>D</td><td>HND/Diploma HE</td><td> 	</td></tr>
 <tr><td>E</td><td>Ordinary degrees</td><td></td></tr>
 </table> 	
- 
+
 ###Format
 String(1)
 

--- a/udd/module_instance.md
+++ b/udd/module_instance.md
@@ -31,7 +31,7 @@ String (255)
 Period to which module instance relates (e.g. semester 1)
 
 ###Purpose
-Analytics 
+Analytics
 
 ###Derivation
 Jisc
@@ -50,14 +50,14 @@ It is expected that sites / organisations will have their own code lists for MOD
 Whether this module instance is delivered wholly online
 
 ###Purpose
-Analytics 
+Analytics
 
 ###Derivation
 Jisc
 
 ###Valid Values
 <table>
-<tr><td>CODE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
+<tr><td>MOD_ONLINE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
 <tr><td>1</td><td>Yes</td><td>Ie  </td></tr>
 <tr><td>2</td><td>No</td><td>Na</td></tr>
 </table>  
@@ -72,7 +72,7 @@ Int
 Academic year that this module runs within - this must represent the start year of that specific academic year eg. for 2014-15 this would be 2014
 
 ###Purpose
-Analytics 
+Analytics
 
 ###Derivation
 Jisc
@@ -91,7 +91,7 @@ This is the starting year for the academic year.
 Whether this instance relates to an optional module or not.
 
 ###Purpose
-Analytics 
+Analytics
 
 ###Derivation
 Jisc
@@ -99,7 +99,7 @@ Jisc
 ###Valid Values
 
 <table>
-<tr><td>CODE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
+<tr><td>MOD_OPTIONAL</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
 <tr><td>1</td><td>Yes</td><td>Ie  </td></tr>
 <tr><td>2</td><td>No</td><td>Na</td></tr>
 </table>  

--- a/udd/student.md
+++ b/udd/student.md
@@ -89,7 +89,7 @@ String (10)
 ###Valid Values & Mappings:  
 
 <table>
-<tr><td>UDD VALUE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)</td><td>HESA(ETHNIC)</td><td>FEILR(ETHNICITY)</td></tr>
+<tr><td>ETHNICITY</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)</td><td>HESA(ETHNIC)</td><td>FEILR(ETHNICITY)</td></tr>
 <tr><td>10</td><td>White</td><td>Gwyn</td><td>10</td><td>31</td></tr>
 <tr><td>13</td><td>White - Scottish</td><td>Gwyn - Alban</td><td>13</td><td>N/A</td></tr>
 <tr><td>51</td><td>Irish</td><td>Gwyddel</td><td>N/A</td><td>32</td></tr>
@@ -114,7 +114,7 @@ String (10)
 <tr><td>98</td><td>Information refused</td><td></td><td>98</td><td>99</td></tr>
 <tr><td>NULL</td><td>No data</td><td> </td><td>NULL</td><td>NULL</td></tr>
 </table>
- 
+
 Please Note - N/A denotes that no mapping value is applicable (and should not be confused with NULL)  
 
 ###Notes
@@ -137,7 +137,7 @@ Int
 ###Valid Values & Mappings
 
 <table>
-<tr><td>UDD VALUE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)</td><td>HESA(SEXID)</td><td>FEILR(SEX)</td></tr>
+<tr><td>SEXID</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)</td><td>HESA(SEXID)</td><td>FEILR(SEX)</td></tr>
 <tr><td>1</td><td>Male</td><td>Gwryw</td><td>1</td><td>M  </td></tr>
 <tr><td>2</td><td>Female</td><td>Beny</td><td>2</td><td>F  </td></tr>
 <tr><td>3</td><td>Other</td><td>Arall</td><td>3</td><td>N/A  </td></tr>
@@ -178,7 +178,7 @@ https://www.hesa.ac.uk/component/studrec/show_file/14051/a%5E_%5ELEARNDIF.html
 ###Valid Values & Mappings
 
 <table>
-<tr><td>UDD VALUE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)</td><td>HESA(LEARNDIF)</td><td>FEILR(LLDDCAT)  </td></tr>
+<tr><td>LEARN_DIF</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)</td><td>HESA(LEARNDIF)</td><td>FEILR(LLDDCAT)  </td></tr>
 <tr><td>1</td><td>Moderate learning difficulty</td><td></td><td>1</td><td>10  </td></tr>
 <tr><td>2</td><td>Severe learning difficulty</td><td></td><td>2</td><td>11  </td></tr>
 <tr><td>10</td><td>Dyslexia</td><td></td><td>10</td><td>12  </td></tr>
@@ -215,7 +215,7 @@ https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&hre
 
 <table>
 <tr>
-<td>UDD VALUE</td>
+<td>DISABILITY1</td>
 <td>DESCRIPTION(ENGLISH)</td>
 <td>DESCRIPTION(WELSH)</td>
 <td>HESA(DISABLE)</td>
@@ -435,7 +435,7 @@ https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&hre
 ###Valid Values & Mappings
 
 <table>
-<tr><td>UDD VALUE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)</td><td>HESA(DISABLE)</td><td>FEILR(LLDDCat)  </td></tr>
+<tr><td>DISABILITY2</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)</td><td>HESA(DISABLE)</td><td>FEILR(LLDDCat)  </td></tr>
 <tr><td>0</td><td>No known disability</td><td>Dim Anabledd</td><td>0</td><td>N/A  </td></tr>
 <tr><td>58</td><td>Blind or a serious visual impairment uncorrected by glasses</td><td></td><td>2</td><td>N/A  </td></tr>
 <tr><td>57</td><td>Deaf or a serious hearing impairment</td><td></td><td>3</td><td>N/A  </td></tr>
@@ -512,7 +512,7 @@ https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&hre
 ###Valid Values & Mappings
 
 <table>
-<tr><td>UDD VALUE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)</td><td>HESA(TTACCOM)</td><td>FEILR(ACCOM)  </td></tr>
+<tr><td>TERMTIME_ACCOM</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)</td><td>HESA(TTACCOM)</td><td>FEILR(ACCOM)  </td></tr>
 <tr><td>1</td><td>Provider maintained property</td><td></td><td>1</td><td>5  </td></tr>
 <tr><td>2</td><td>Parental/guardian home</td><td></td><td>2</td><td>N/A  </td></tr>
 <tr><td>4</td><td>Other</td><td>Arall</td><td>4</td><td>NULL  </td></tr>
@@ -553,7 +553,7 @@ https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&hre
 ###Valid Values
 
 <table>
-<tr><td>UDD VALUE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
+<tr><td>PARENTS_ED</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
 <tr><td>1</td><td>Yes</td><td>Ie  </td></tr>
 <tr><td>2</td><td>No</td><td>Na  </td></tr>
 <tr><td>7</td><td>No response given</td><td>Dim Ateb  </td></tr>
@@ -586,7 +586,7 @@ https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&hre
 ###Valid Values
 
 <table>
-<tr><td>UDD VALUE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
+<tr><td>SOCIO_EC</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
 <tr><td>1</td><td>Higher managerial &amp; professional occupations</td><td>  </td></tr>
 <tr><td>2</td><td>Lower managerial &amp; professional occupations</td><td>   </td></tr>
 <tr><td>3</td><td>Intermediate occupations</td><td>  </td></tr>
@@ -623,7 +623,7 @@ Jisc
 ###Valid Values
 
 <table>
-<tr><td>UDD VALUE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)</td></tr>
+<tr><td>OVERSEAS</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)</td></tr>
 <tr><td>1</td><td>United Kingdom</td><td>Deyrnas Unedig  </td></tr>
 <tr><td>2</td><td>Europe (EU)</td><td>Ewrop (UE)  </td></tr>
 <tr><td>3</td><td>Rest of the World (Overseas)</td><td>Gweddill y Byd  </td></tr>
@@ -647,7 +647,7 @@ If this value is unknown, then code '99' should be used. The mapping for these f
 The person identifier used by Shibboleth / The UK Access Management Federation to grant access to the Jisc analytics student app via the Shibboleth - JWT gateway.
 
 ###Purpose
-Analytics 
+Analytics
 
 ###Derivation
 https://www.internet2.edu/media/medialibrary/2013/09/04/internet2-mace-dir-eduperson-200604.html
@@ -667,10 +667,10 @@ There may be a more general AIM_ID property later that can be used for any UK Fe
 The ID assigned to a student by the VLE.
 
 ###Purpose
-Analytics 
+Analytics
 
 ###Derivation
-Jisc 
+Jisc
 
 ###Valid Values
 Not specified
@@ -687,19 +687,16 @@ Note that this is not a universal user ID; there maybe several VLEs, or records 
 A HESA student identifier unique to each student. It is intended that the identifier is to be transferred with the student to each provider of higher education he or she may attend. The objective is that the use of this number will facilitate the accurate tracking of students throughout their experience within the sector for which HESA collects data.
 
 ###Purpose
-Analytics 
+Analytics
 
 ###Derivation
 https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=15051&href=a^_^HUSID.html
 
-###Valid Values
-<table>
-<tbody><tr><td>First 2 digits:</td><td>Year of entry into provider (last 2 digits of year)</td></tr>
-<tr><td>Next 4 digits:</td><td>HESA institution identifier + 1000</td></tr>
-<tr><td>Next 6 digits:</td><td>6 digit reference number internally allocated by provider.</td></tr>
-<tr><td>Last digit:</td><td>Check digit.</td></tr>
-</tbody>
-</table>
+###Format of Valid Values
+- First 2 digits:</td><td>Year of entry into provider (last 2 digits of year)
+- Next 4 digits:</td><td>HESA institution identifier + 1000
+- Next 6 digits:</td><td>6 digit reference number internally allocated by provider.
+- Last digit:</td><td>Check digit.
 
 ###Format
 String (13)

--- a/udd/student.md
+++ b/udd/student.md
@@ -229,45 +229,15 @@ https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&hre
 <td>N/A </td>
 </tr>
 <tr>
-<td>58</td>
-<td>Blind or a serious visual impairment uncorrected by glasses</td>
-<td></td>
-<td>2</td>
-<td>N/A </td>
-</tr>
-<tr>
-<td>57</td>
-<td>Deaf or a serious hearing impairment</td>
-<td></td>
-<td>3</td>
-<td>N/A </td>
-</tr>
-<tr>
-<td>56</td>
-<td>A physical impairment or mobility issues such as difficulty using arms or using
-a wheelchair or crutches</td>
-<td></td>
-<td>4</td>
-<td>N/A </td>
-</tr>
-<tr>
-<td>96</td>
-<td>A disability impairment or medical condition that is not listed above</td>
+<td>5</td>
+<td>Personal care support</td>
 <td></td>
 <td>5</td>
 <td>N/A </td>
 </tr>
 <tr>
-<td>55</td>
-<td>A mental health condition such as depression schizophrenia or anxiety
-disorder</td>
-<td></td>
-<td>6</td>
-<td>N/A </td>
-</tr>
-<tr>
-<td>96</td>
-<td>A disability impairment or medical condition that is not listed above</td>
+<td>7</td>
+<td>An unseen disability, e.g. diabetes, epilepsy, asthma</td>
 <td></td>
 <td>7</td>
 <td>N/A </td>
@@ -292,15 +262,7 @@ disorder</td>
 spectrum disorder</td>
 <td></td>
 <td>53</td>
-<td>15 </td>
-</tr>
-<tr>
-<td>53</td>
-<td>A social/communication impairment such as Asperger's syndrome/other autistic
-spectrum disorder</td>
-<td></td>
-<td>N/A</td>
-<td>1 </td>
+<td>15, 1</td>
 </tr>
 <tr>
 <td>54</td>
@@ -315,7 +277,7 @@ heart disease or epilepsy</td>
 <td>A mental health condition such as depression schizophrenia or anxiety
 disorder</td>
 <td></td>
-<td>55</td>
+<td>6, 55</td>
 <td>9 </td>
 </tr>
 <tr>
@@ -323,29 +285,21 @@ disorder</td>
 <td>A physical impairment or mobility issues such as difficulty using arms or using
 a wheelchair or crutches</td>
 <td></td>
-<td>56</td>
-<td>6 </td>
-</tr>
-<tr>
-<td>56</td>
-<td>A physical impairment or mobility issues such as difficulty using arms or using
-a wheelchair or crutches</td>
-<td></td>
-<td>N/A</td>
-<td>93 </td>
+<td>4, 56</td>
+<td>6, 93</td>
 </tr>
 <tr>
 <td>57</td>
 <td>Deaf or a serious hearing impairment</td>
 <td></td>
-<td>57</td>
+<td>3, 57</td>
 <td>5 </td>
 </tr>
 <tr>
 <td>58</td>
 <td>Blind or a serious visual impairment uncorrected by glasses</td>
 <td></td>
-<td>58</td>
+<td>2, 58</td>
 <td>4 </td>
 </tr>
 <tr>
@@ -353,56 +307,28 @@ a wheelchair or crutches</td>
 <td>A disability impairment or medical condition that is not listed above</td>
 <td></td>
 <td>96</td>
-<td>7 </td>
+<td>7, 8, 16, 97</td>
 </tr>
 <tr>
-<td>96</td>
-<td>A disability impairment or medical condition that is not listed above</td>
-<td></td>
-<td>N/A</td>
-<td>8 </td>
-</tr>
-<tr>
-<td>96</td>
-<td>A disability impairment or medical condition that is not listed above</td>
-<td></td>
-<td>N/A</td>
-<td>16 </td>
-</tr>
-<tr>
-<td>96</td>
-<td>A disability impairment or medical condition that is not listed above</td>
-<td></td>
-<td>N/A</td>
-<td>97 </td>
-</tr>
-<tr>
-<td>00</td>
+<td>97</td>
 <td>Information refused</td>
 <td></td>
 <td>97</td>
 <td>98 </td>
 </tr>
 <tr>
-<td>00</td>
+<td>98</td>
 <td>Information not sought</td>
 <td></td>
 <td>98</td>
 <td>N/A </td>
 </tr>
 <tr>
-<td>00</td>
+<td>99</td>
 <td>Not known</td>
 <td>Anhysbys</td>
 <td>99</td>
 <td>99 </td>
-</tr>
-<tr>
-<td>00</td>
-<td>No known disability</td>
-<td>Dim Anabledd</td>
-<td>00</td>
-<td>N/A</td>
 </tr>
 <tr>
 <td>NULL</td>
@@ -435,32 +361,122 @@ https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&hre
 ###Valid Values & Mappings
 
 <table>
-<tr><td>DISABILITY2</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)</td><td>HESA(DISABLE)</td><td>FEILR(LLDDCat)  </td></tr>
-<tr><td>0</td><td>No known disability</td><td>Dim Anabledd</td><td>0</td><td>N/A  </td></tr>
-<tr><td>58</td><td>Blind or a serious visual impairment uncorrected by glasses</td><td></td><td>2</td><td>N/A  </td></tr>
-<tr><td>57</td><td>Deaf or a serious hearing impairment</td><td></td><td>3</td><td>N/A  </td></tr>
-<tr><td>56</td><td>A physical impairment or mobility issues such as difficulty using arms or using a wheelchair or crutches</td><td></td><td>4</td><td>N/A  </td></tr>
-<tr><td>96</td><td>A disability impairment or medical condition that is not listed above</td><td></td><td>5</td><td>N/A  </td></tr>
-<tr><td>55</td><td>A mental health condition such as depression schizophrenia or anxiety disorder</td><td></td><td>6</td><td>N/A  </td></tr>
-<tr><td>96</td><td>A disability impairment or medical condition that is not listed above</td><td></td><td>7</td><td>N/A  </td></tr>
-<tr><td>8</td><td>Two or more impairments and/or disabling medical conditions</td><td></td><td>8</td><td>2  </td></tr>
-<tr><td>51</td><td>A specific learning difficulty such as dyslexia dyspraxia or AD(H)D</td><td></td><td>11</td><td>12  </td></tr>
-<tr><td>53</td><td>A social/communication impairment such as Asperger's syndrome/other autistic spectrum disorder</td><td></td><td>53</td><td>15  </td></tr>
-<tr><td>53</td><td>A social/communication impairment such as Asperger's syndrome/other autistic spectrum disorder</td><td></td><td>N/A</td><td>1  </td></tr>
-<tr><td>54</td><td>A long standing illness or health condition such as cancer HIV diabetes chronic heart disease or epilepsy</td><td></td><td>54</td><td>95  </td></tr>
-<tr><td>55</td><td>A mental health condition such as depression schizophrenia or anxiety disorder</td><td></td><td>55</td><td>9  </td></tr>
-<tr><td>56</td><td>A physical impairment or mobility issues such as difficulty using arms or using a wheelchair or crutches</td><td></td><td>56</td><td>6  </td></tr>
-<tr><td>56</td><td>A physical impairment or mobility issues such as difficulty using arms or using a wheelchair or crutches</td><td></td><td>N/A</td><td>93  </td></tr>
-<tr><td>57</td><td>Deaf or a serious hearing impairment</td><td></td><td>57</td><td>5  </td></tr>
-<tr><td>58</td><td>Blind or a serious visual impairment uncorrected by glasses</td><td></td><td>58</td><td>4  </td></tr>
-<tr><td>96</td><td>A disability impairment or medical condition that is not listed above</td><td></td><td>96</td><td>7  </td></tr>
-<tr><td>96</td><td>A disability impairment or medical condition that is not listed above</td><td></td><td>N/A</td><td>8  </td></tr>
-<tr><td>96</td><td>A disability impairment or medical condition that is not listed above</td><td></td><td>N/A</td><td>16  </td></tr>
-<tr><td>96</td><td>A disability impairment or medical condition that is not listed above</td><td></td><td>N/A</td><td>97  </td></tr>
-<tr><td>00</td><td>Information refused</td><td></td><td>97</td><td>98  </td></tr>
-<tr><td>00</td><td>Information not sought</td><td></td><td>98</td><td>N/A  </td></tr>
-<tr><td>00</td><td>Not known</td><td>Anhysbys</td><td>99</td><td>99  </td></tr>
-<tr><td>00</td><td>No known disability</td><td>Dim Anabledd</td><td>00</td><td>N/A  </td></tr>
+<tr>
+<td>DISABILITY2</td>
+<td>DESCRIPTION(ENGLISH)</td>
+<td>DESCRIPTION(WELSH)</td>
+<td>HESA(DISABLE)</td>
+<td>FEILR(LLDDCat) </td>
+</tr>
+<tr>
+<td>0</td>
+<td>No known disability</td>
+<td>Dim Anabledd</td>
+<td>0</td>
+<td>N/A </td>
+</tr>
+<tr>
+<td>5</td>
+<td>Personal care support</td>
+<td></td>
+<td>5</td>
+<td>N/A </td>
+</tr>
+<tr>
+<td>7</td>
+<td>An unseen disability, e.g. diabetes, epilepsy, asthma</td>
+<td></td>
+<td>7</td>
+<td>N/A </td>
+</tr>
+<tr>
+<td>8</td>
+<td>Two or more impairments and/or disabling medical conditions</td>
+<td></td>
+<td>8</td>
+<td>2 </td>
+</tr>
+<tr>
+<td>51</td>
+<td>A specific learning difficulty such as dyslexia dyspraxia or AD(H)D</td>
+<td></td>
+<td>11</td>
+<td>12 </td>
+</tr>
+<tr>
+<td>53</td>
+<td>A social/communication impairment such as Asperger's syndrome/other autistic
+spectrum disorder</td>
+<td></td>
+<td>53</td>
+<td>15, 1</td>
+</tr>
+<tr>
+<td>54</td>
+<td>A long standing illness or health condition such as cancer HIV diabetes chronic
+heart disease or epilepsy</td>
+<td></td>
+<td>54</td>
+<td>95 </td>
+</tr>
+<tr>
+<td>55</td>
+<td>A mental health condition such as depression schizophrenia or anxiety
+disorder</td>
+<td></td>
+<td>6, 55</td>
+<td>9 </td>
+</tr>
+<tr>
+<td>56</td>
+<td>A physical impairment or mobility issues such as difficulty using arms or using
+a wheelchair or crutches</td>
+<td></td>
+<td>4, 56</td>
+<td>6, 93</td>
+</tr>
+<tr>
+<td>57</td>
+<td>Deaf or a serious hearing impairment</td>
+<td></td>
+<td>3, 57</td>
+<td>5 </td>
+</tr>
+<tr>
+<td>58</td>
+<td>Blind or a serious visual impairment uncorrected by glasses</td>
+<td></td>
+<td>2, 58</td>
+<td>4 </td>
+</tr>
+<tr>
+<td>96</td>
+<td>A disability impairment or medical condition that is not listed above</td>
+<td></td>
+<td>96</td>
+<td>7, 8, 16, 97</td>
+</tr>
+<tr>
+<td>97</td>
+<td>Information refused</td>
+<td></td>
+<td>97</td>
+<td>98 </td>
+</tr>
+<tr>
+<td>98</td>
+<td>Information not sought</td>
+<td></td>
+<td>98</td>
+<td>N/A </td>
+</tr>
+<tr>
+<td>99</td>
+<td>Not known</td>
+<td>Anhysbys</td>
+<td>99</td>
+<td>99 </td>
+</tr>
 <tr>
 <td>NULL</td>
 <td>No data</td>
@@ -468,7 +484,7 @@ https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&hre
 <td>NULL</td>
 <td>NULL</td>
 </tr>
-</table>
+</table>  
 
 Please Note - N/A denotes that no mapping value is applicable (and should not be confused with NULL)  
 
@@ -521,7 +537,6 @@ https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&hre
 <tr><td>7</td><td>Own residence</td><td></td><td>7</td><td>N/A  </td></tr>
 <tr><td>8</td><td>Other rented accommodation</td><td></td><td>8</td><td>N/A  </td></tr>
 <tr><td>9</td><td>Private-sector halls</td><td></td><td>9</td><td>N/A  </td></tr>
-<tr><td>5</td><td>Not known</td><td>Anhysbys</td><td>N/A</td><td>N/A </td></tr>
 <tr>
 <td>NULL</td>
 <td>No data</td>

--- a/udd/student_course_membership.md
+++ b/udd/student_course_membership.md
@@ -70,9 +70,9 @@ https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/449779
 https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&href=a^_^WITHDRAWREASON.html
 https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&href=a^_^RSNEND.html
 
-###Valid Values & Mappings 
+###Valid Values & Mappings
 <table>
-<tr><td>CODE</td><td>DESCRIPTION (ENGLISH)</td><td>DESCRIPTION (WELSH)</td><td>HESA (WITHDRAWREASON)</td><td>HESA (RSNEND)</td><td>FEILR (WITHDRAWREASON)  </td></tr>
+<tr><td>WITHDRAWAL_REASON</td><td>DESCRIPTION (ENGLISH)</td><td>DESCRIPTION (WELSH)</td><td>HESA (WITHDRAWREASON)</td><td>HESA (RSNEND)</td><td>FEILR (WITHDRAWREASON)  </td></tr>
 <tr><td>2</td><td>Learner has transferred to another provider</td><td></td><td>02</td><td>03</td><td>2  </td></tr>
 <tr><td>3</td><td>Learner injury / illness</td><td></td><td>03</td><td>04</td><td>3   </td></tr>
 <tr><td>5</td><td>Death</td><td></td><td>N/A</td><td>05</td><td>N/A  </td></tr>
@@ -132,7 +132,7 @@ https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&hre
 
 ###Valid Values & Mappings
 <table>
-<tr><td>CODE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)</td><td>HESA(QUALENT3)</td><td>FEILR(PRIORATTAIN)   </td></tr>
+<tr><td>ENTRY_QUALS</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)</td><td>HESA(QUALENT3)</td><td>FEILR(PRIORATTAIN)   </td></tr>
 <tr><td>DUK</td><td>UK doctorate degree</td><td></td><td>DUK</td><td> 	</td></tr>
 <tr><td>DZZ</td><td>Non-UK doctorate degree</td><td></td><td>DZZ</td><td>  	</td></tr>
 <tr><td>D80</td><td>Other qualification at level D</td><td></td><td>D80</td><td>  	</td></tr>
@@ -197,7 +197,7 @@ https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&hre
 <tr><td>X05</td><td>Student has no formal qualification</td><td></td><td>X05</td><td>99  </td></tr>
 <tr><td>X06</td><td>Not known</td><td></td><td>X06</td><td>98  </td></tr>
 <tr><td>NULL</td><td>No data</td><td></td><td>NULL</td><td>NULL </td></tr>
-</table> 
+</table>
 
 ###Format
 Alphanumeric
@@ -257,7 +257,7 @@ https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&hre
 ###Valid Values
 
 <table>
-<tr><td>CODE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
+<tr><td>COURSE_GRADE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
 <tr><td>1</td><td>First class honours</td><td>  	</td></tr>
 <tr><td>2</td><td>Upper second class honours</td><td>  	</td></tr>
 <tr><td>3</td><td>Lower second class honours</td><td> 	</td></tr>

--- a/udd/student_course_membership.md
+++ b/udd/student_course_membership.md
@@ -154,7 +154,6 @@ https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&hre
 <tr><td>J10</td><td>Foundation degree</td><td></td><td>J10</td><td>  </td></tr>
 <tr><td>J20</td><td>Diploma of Higher Education (DipHE)</td><td></td><td>J20</td><td>  	</td></tr>
 <tr><td>J30</td><td>Higher National Diploma (HND)</td><td></td><td>J30</td><td>  	</td></tr>
-<tr><td>J31</td><td>(Other) Qualification at level 5</td><td></td><td></td><td>  		</td></tr>
 <tr><td>J31</td><td>(Other) Qualification at level 5 or above (DEPRECATED SINCE 01/08/2013)</td><td></td><td>J32</td><td>5  </td></tr>
 <tr><td>J49</td><td>Foundation course at level J</td><td></td><td>J49</td><td>  	</td></tr>
 <tr><td>J48</td><td>Certificate in Education (CertEd) or Diploma in Education (DipEd) (i.e. non-graduate initial teacher training qualification)</td><td></td><td>J48</td><td>  	</td></tr>
@@ -162,8 +161,7 @@ https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&hre
 <tr><td>C20</td><td>Certificate of Higher Education (CertHE)</td><td></td><td>C20</td><td>  	</td></tr>
 <tr><td>C30</td><td>Higher National Certificate (HNC)</td><td></td><td>C30</td><td> 	</td></tr>
 <tr><td>C44</td><td>Higher Apprenticeship (level 4)</td><td></td><td>C44</td><td>  	</td></tr>
-<tr><td>C80</td><td>(Other) Qualification at level C or level 4</td><td></td><td>C80</td><td>4  </td></tr>
-<tr><td>C80</td><td>(Other) Qualification at level C or level 4</td><td></td><td>N/A</td><td>10  </td></tr>
+<tr><td>C80</td><td>(Other) Qualification at level C or level 4</td><td></td><td>C80</td><td>4, 10  </td></tr>
 <tr><td>C90</td><td>Undergraduate credits</td><td></td><td>C90</td><td>  	</td></tr>
 <tr><td>P41</td><td>Diploma at level 3</td><td></td><td>P41</td><td>  	</td></tr>
 <tr><td>P42</td><td>Certificate at level 3</td><td></td><td>P42</td><td>  	</td></tr>

--- a/udd/student_on_a_module_instance.md
+++ b/udd/student_on_a_module_instance.md
@@ -25,7 +25,7 @@
 Final grade student achieved on the module.
 
 ###Purpose
-Analytics 
+Analytics
 
 ###Derivation
 Jisc
@@ -44,7 +44,7 @@ String (256)
 Indicates whether the student passed the module, didn't pass the module, deferred the module or whether this information is not known because the module hasn't been completed yet.
 
 ###Purpose
-Analytics 
+Analytics
 
 ###Derivation
 Jisc
@@ -52,7 +52,7 @@ Jisc
 ###Valid Values
 
 <table>
-<tr><td>CODE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
+<tr><td>MOD_RESULT</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
 <tr><td>1</td><td>Yes</td><td>Ie  </td></tr>
 <tr><td>2</td><td>No</td><td>Na  </td></tr>
 <tr><td>3</td><td>Not completed yet</td><td>Dim wedi cwblhau</td></tr>
@@ -71,7 +71,7 @@ Code 3 is applied in all cases where the outcome is either not known (yet), or d
 Whether this is a retake of the module for that student.
 
 ###Purpose
-Analytics 
+Analytics
 
 ###Derivation
 Jisc
@@ -79,9 +79,9 @@ Jisc
 ###Valid Values
 
 <table>
-<tr><td>    CODE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
-<tr><td>    1</td><td>Yes</td><td>Ie  </td></tr>
-<tr><td>    2</td><td>No</td><td>Na</td></tr>
+<tr><td>MOD_RETAKE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
+<tr><td>1</td><td>Yes</td><td>Ie  </td></tr>
+<tr><td>2</td><td>No</td><td>Na</td></tr>
 </table>  
 
 ###Format

--- a/udd/student_on_assessment_instance.md
+++ b/udd/student_on_assessment_instance.md
@@ -53,7 +53,7 @@ Jisc
 YYYY-MM-DD
 
 ###Format
-ISO 8601 
+ISO 8601
 
 ###Notes
 
@@ -69,11 +69,11 @@ Analytics
 Jisc
 
 ###Valid Values
-
-|code|description (English)|description (Welsh)|
-|---|---|---|
-|1|Yes|Ie|
-|2|No|Na|
+<table>
+<tr><td>ASSESS_RETAKE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
+<tr><td>1</td><td>Yes</td><td>Ie  </td></tr>
+<tr><td>2</td><td>No</td><td>Na</td></tr>
+</table>  
 
 ###Format
 Integer
@@ -188,7 +188,7 @@ Jisc; student_on_a_module_instance.MOD_RESULT
 
 ###Valid Values
 <table>
-<tr><td>CODE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
+<tr><td>ASSESSMENT_RESULT</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)  </td></tr>
 <tr><td>1</td><td>Yes</td><td>Ie  </td></tr>
 <tr><td>2</td><td>No</td><td>Na  </td></tr>
 <tr><td>3</td><td>Not completed yet</td><td>Dim wedi cwblhau</td></tr>
@@ -207,7 +207,7 @@ Code 3 is applied in all cases where the outcome is either not known (yet), or d
 The date at which the grade result has been confirmed and awarded.
 
 ###Purpose
-Analytics 
+Analytics
 
 ###Derivation
 Jisc
@@ -227,7 +227,7 @@ This is the date when a grade has been moderated and agreed, but before exam boa
 The maximum points that an instructor can allocate to an assessment. Used to indicate the marking scale used for an assignment.
 
 ###Purpose
-Analytics 
+Analytics
 
 ###Derivation
 Jisc
@@ -253,7 +253,7 @@ Implementation optimisation
 Jisc; assessment_instance.ASSESS_DETAIL
 
 ###Valid Values
-Any 
+Any
 
 ###Format
 String (255)
@@ -273,7 +273,7 @@ Implementation optimisation
 Jisc; module.MOD_ID
 
 ###Valid Values
-Any 
+Any
 
 ###Format
 String (255)

--- a/udd/student_on_course_instance.md
+++ b/udd/student_on_course_instance.md
@@ -24,7 +24,7 @@ https://www.hesa.ac.uk/index.php?option=com_studrec&task=show_file&mnl=14051&hre
 ###Valid Values & Mappings
 
 <table>
-<tr><td>CODE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)</td><td>HESA(MODE)</td><td>FEILR(PlanLearnHours)  </td></tr>
+<tr><td>MODE</td><td>DESCRIPTION(ENGLISH)</td><td>DESCRIPTION(WELSH)</td><td>HESA(MODE)</td><td>FEILR(PlanLearnHours)  </td></tr>
 <tr><td>1</td><td>Full-time according to funding council definitions</td><td></td><td>1</td><td>PlanLearnHours > 540  </td></tr>
 <tr><td>2</td><td>Other full-time</td><td></td><td>2</td><td>N/A  </td></tr>
 <tr><td>12</td><td>FE students full-time 30 weeks or more</td><td></td><td>12</td><td>N/A  </td></tr>


### PR DESCRIPTION
plus found one table in MD (assessment result), changed to html

also changed documentation of HUSID structure from being a table.

second commit does a few things:
- remove some unambiguous duplicates (100% identical rows)
- remove some semantic duplicates (e.g. "0" and "00" appear as codes in disability but are otherwise identical rows
- collapse differences of mapping (e.g. disability code 96 had several rows differing only in columns showing mapping to FEILR/HESA - these are now collapsed to comma separated lists in the appropriate column for a single row in the table, rather than each having its own entry)
- change some code 96 entries in disability to reflect HESA codes which seem to have got lost (HESA DISABLE 5 and 7). I believe this is the only change which has any consequence on the codes which might actually be used.