### PR TITLE
course.SUBJECT and module.MOD_SUBJECT deleted

### DIFF
--- a/udd/course.md
+++ b/udd/course.md
@@ -1,7 +1,6 @@
 # course
 * [COURSE_ID](#course_id) [1] **
 * [TENANT_ID](institution.md#tenant_id) [1]
-* [SUBJECT](#subject) [0..1] deprecated
 * [TITLE](#title) [0..1]
 * [COURSE_AIM](#course_aim) [0..1]
 * [INST_TIER_1](#inst_tier_1) [0..1]
@@ -18,7 +17,7 @@ API endpoint name: **course**
 A course is a learning opportunity that defines a student's learning activities and aim. It is run by an institution and is usually validated to continue over several years with several intakes. A course will usually have a qualification aim.  Example: BA Honours degree in French.
 
 ## Notes
-The properties of the course entity do not include start date, study mode or location, because the course is at a high level in the UDD structure.  These properties of a learning opportunity are differentiated in the course_instance, student_course_membership and student_on_course_instance entities.
+The properties of the course entity do not include start date, study mode or location, because the course is at a high level in the UDD structure. These properties of a learning opportunity are differentiated in the course_instance, student_course_membership and student_on_course_instance entities.
 
 ## COURSE_ID
 ### Description
@@ -39,29 +38,6 @@ String (255)
 
 ### Notes
 HE guidance - this field could relate to actual HESA COURSEID field or the HE institution's OWNCOURSEID field for cross-referencing purposes.
-
-## SUBJECT
-### Description
-Subject of study coding using JACS3.
-DEPRECATED in v1.4. Use course_subject entity for preference.
-
-### Purpose
-For display purposes
-
-### Derivation
-https://www.hesa.ac.uk/collection/c18051/a/sbjca
-
-https://www.hesa.ac.uk/support/documentation/jacs
-
-### Valid Values
-[JACS3 CSV](../media/jacs3-valid-entries.csv)
-
-### Format
-String (10) - For JACS3: 4 characters, capital letter followed by three digits
-
-### Notes
-The JACS3 coding will be used here initially, from the HE (HESA) model. Further discussion will be required around this, to discuss subject classifications for FE/ ILR.
-Omitting this property could impair the functionality of analytics applications such as student apps or dashboards.
 
 ## TITLE
 ### Description

--- a/udd/module.md
+++ b/udd/module.md
@@ -1,7 +1,6 @@
 # module
 * [MOD_ID](#mod_id) [1] **
 * [MOD_NAME](#mod_name) [0..1]
-* [MOD_SUBJECT](#mod_subject) [0..1] deprecated
 * [MOD_CREDITS](#mod_credits) [0..1]
 * [MOD_LEVEL](#mod_level) [0..1]
 * [CREDIT_BEARING](#credit_bearing) [0..1]
@@ -35,7 +34,6 @@ String (255)
 
 ### Notes
 
-
 ## MOD_NAME
 ### Description
 The actual name of the module
@@ -54,30 +52,6 @@ String (255)
 
 ### Notes
 Omitting this property could impair the functionality of analytics applications such as student apps or dashboards.
-
-## MOD_SUBJECT
-### Description
-Module subject - coded using JACS3 subject codes
-DEPRECATED in v1.4. Use module_subject entity for preference.
-
-### Purpose
-For display purposes and analytics.
-
-### Derivation
-https://www.hesa.ac.uk/collection/c18051/a/modsbj
-
-https://www.hesa.ac.uk/support/documentation/jacs
-
-### Valid Values
-[JACS3 CSV](../media/jacs3-valid-entries.csv)
-
-### Format
-String (255) - For JACS3: 4 characters, capital letter followed by three digits
-
-### Notes
-For FE purposes, it will need be adapted to work with institutions specific codeset for Learning Activities. Details to be confirmed.
-Omitting this property may hinder the development or use of an effective analytics model.
-
 
 ## MOD_CREDITS
 ### Description


### PR DESCRIPTION
course.SUBJECT and module.MOD_SUBJECT deleted. These were deprecated in v1.4. Use course_subject and module_subject entities instead.
#328 refers.